### PR TITLE
Fix ezCollections ElvUI microbar error

### DIFF
--- a/ezCollections/Core/ElvUI/MicroBar.lua
+++ b/ezCollections/Core/ElvUI/MicroBar.lua
@@ -1,48 +1,74 @@
 ezCollections:MergeHook("ezCollectionsElvUIHook", function()
 
-local E, L, V, P, G = unpack(ElvUI);
-local AB = E:GetModule("ActionBars")
+-- Wrap everything in pcall to prevent errors from breaking the addon
+local success, errorMsg = pcall(function()
+	local E, L, V, P, G = unpack(ElvUI);
+	if not E then return end
 
-hooksecurefunc(AB, "UpdateMicroButtonsParent", function(self)
-	CollectionsMicroButton:SetParent(ElvUI_MicroBar);
-	AB:UpdateMicroPositionDimensions()
-end);
+	local AB = E:GetModule("ActionBars")
+	if not AB then return end
 
-hooksecurefunc(AB, "UpdateMicroPositionDimensions", function(self)
-	if not ElvUI_MicroBar then return end
-	if not AB.ezCollectionsMicroButtons then return end
-	local MICRO_BUTTONS = AB.ezCollectionsMicroButtons;
-
-	local numRows = 1
-	local prevButton = ElvUI_MicroBar
-	local offset = E:Scale(E.PixelMode and 1 or 3)
-	local spacing = E:Scale(offset + self.db.microbar.buttonSpacing)
-
-	for i = 1, #MICRO_BUTTONS do
-		local button = MICRO_BUTTONS[i]
-		local lastColumnButton = i - self.db.microbar.buttonsPerRow
-		lastColumnButton = MICRO_BUTTONS[lastColumnButton];
-
-		button:Size(self.db.microbar.buttonSize, self.db.microbar.buttonSize * 1.4)
-		button:ClearAllPoints()
-		button:Show();
-
-		if prevButton == ElvUI_MicroBar then
-			button:Point("TOPLEFT", prevButton, "TOPLEFT", offset, -offset)
-		elseif (i - 1) % self.db.microbar.buttonsPerRow == 0 then
-			button:Point("TOP", lastColumnButton, "BOTTOM", 0, -spacing)
-			numRows = numRows + 1
-		else
-			button:Point("LEFT", prevButton, "RIGHT", spacing, 0)
-		end
-
-		prevButton = button
+	-- Check if UpdateMicroButtonsParent exists before hooking
+	if AB.UpdateMicroButtonsParent then
+		hooksecurefunc(AB, "UpdateMicroButtonsParent", function(self)
+			if CollectionsMicroButton and ElvUI_MicroBar then
+				CollectionsMicroButton:SetParent(ElvUI_MicroBar);
+				-- Removed problematic call to UpdateMicroPositionDimensions() since it doesn't exist
+				if AB.UpdateMicroButtons then
+					AB:UpdateMicroButtons()
+				end
+			end
+		end);
 	end
-end);
 
-hooksecurefunc(AB, "SetupMicroBar", function(self)
-	self:HandleMicroButton(CollectionsMicroButton);
-end);
+	-- Check if UpdateMicroButtons exists before hooking
+	if AB.UpdateMicroButtons then
+		hooksecurefunc(AB, "UpdateMicroButtons", function(self)
+			if not ElvUI_MicroBar then return end
+			if not AB.ezCollectionsMicroButtons then return end
+			local MICRO_BUTTONS = AB.ezCollectionsMicroButtons;
+
+			local numRows = 1
+			local prevButton = ElvUI_MicroBar
+			local offset = E:Scale(E.PixelMode and 1 or 3)
+			local spacing = E:Scale(offset + self.db.microbar.buttonSpacing)
+
+			for i = 1, #MICRO_BUTTONS do
+				local button = MICRO_BUTTONS[i]
+				local lastColumnButton = i - self.db.microbar.buttonsPerRow
+				lastColumnButton = MICRO_BUTTONS[lastColumnButton];
+
+				button:Size(self.db.microbar.buttonSize, self.db.microbar.buttonSize * 1.4)
+				button:ClearAllPoints()
+				button:Show();
+
+				if prevButton == ElvUI_MicroBar then
+					button:Point("TOPLEFT", prevButton, "TOPLEFT", offset, -offset)
+				elseif (i - 1) % self.db.microbar.buttonsPerRow == 0 then
+					button:Point("TOP", lastColumnButton, "BOTTOM", 0, -spacing)
+					numRows = numRows + 1
+				else
+					button:Point("LEFT", prevButton, "RIGHT", spacing, 0)
+				end
+
+				prevButton = button
+			end
+		end);
+	end
+
+	-- Check if SetupMicroBar exists before hooking
+	if AB.SetupMicroBar then
+		hooksecurefunc(AB, "SetupMicroBar", function(self)
+			if CollectionsMicroButton and self.HandleMicroButton then
+				self:HandleMicroButton(CollectionsMicroButton);
+			end
+		end);
+	end
+end)
+
+if not success then
+	print("ezCollections ElvUI Hook Error: " .. tostring(errorMsg))
+end
 
 end);
 ezCollections:MergeHook("ezCollectionsElvUIConfigHook", function()

--- a/ezCollections/ezCollections.lua
+++ b/ezCollections/ezCollections.lua
@@ -943,7 +943,10 @@ function addon:OnInitialize()
                 local E = unpack(ElvUI);
                 local AB = E:GetModule("ActionBars");
                 AB.ezCollectionsMicroButtons = buttons;
-                AB:UpdateMicroPositionDimensions();
+                -- Use UpdateMicroButtons instead of the non-existent UpdateMicroPositionDimensions
+                if AB.UpdateMicroButtons then
+                    AB:UpdateMicroButtons();
+                end
                 return;
             end
             microButtonInserted = inserted;


### PR DESCRIPTION
<pr_request_template>
Fix Lua errors in ezCollections by updating ElvUI micro bar function calls and adding defensive checks.

The `UpdateMicroPositionDimensions` function used by ezCollections no longer exists in the target ElvUI version. This PR replaces it with `UpdateMicroButtons` and adds `pcall` and existence checks to prevent future errors.
</pr_request_template>

---

[Open in Web](https://cursor.com/agents?id=bc-db379ff1-67ef-41e1-8696-504e6f36eef7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-db379ff1-67ef-41e1-8696-504e6f36eef7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)