### PR TITLE
Fix elvui microbar table index nil error

### DIFF
--- a/ezCollections/Core/ElvUI/MicroBar.lua
+++ b/ezCollections/Core/ElvUI/MicroBar.lua
@@ -26,7 +26,17 @@ local success, errorMsg = pcall(function()
 		hooksecurefunc(AB, "UpdateMicroButtons", function(self)
 			if not ElvUI_MicroBar then return end
 			if not AB.ezCollectionsMicroButtons then return end
-			local MICRO_BUTTONS = AB.ezCollectionsMicroButtons;
+			
+			-- Filter out nil buttons to prevent "table index is nil" error
+			local MICRO_BUTTONS = {};
+			for i, button in ipairs(AB.ezCollectionsMicroButtons) do
+				if button and button:IsObjectType("Button") then
+					table.insert(MICRO_BUTTONS, button);
+				end
+			end
+			
+			-- If no valid buttons, return early
+			if #MICRO_BUTTONS == 0 then return end
 
 			local numRows = 1
 			local prevButton = ElvUI_MicroBar

--- a/ezCollections/ezCollections.lua
+++ b/ezCollections/ezCollections.lua
@@ -942,7 +942,14 @@ function addon:OnInitialize()
             if ElvUI then
                 local E = unpack(ElvUI);
                 local AB = E:GetModule("ActionBars");
-                AB.ezCollectionsMicroButtons = buttons;
+                -- Filter out nil buttons before assigning to prevent table index errors
+                local validButtons = {};
+                for i, button in ipairs(buttons) do
+                    if button and button:IsObjectType and button:IsObjectType("Button") then
+                        table.insert(validButtons, button);
+                    end
+                end
+                AB.ezCollectionsMicroButtons = validButtons;
                 -- Use UpdateMicroButtons instead of the non-existent UpdateMicroPositionDimensions
                 if AB.UpdateMicroButtons then
                     AB:UpdateMicroButtons();


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "table index is nil" error in ElvUI MicroBar by filtering out nil and invalid button objects.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error occurred because `AB.ezCollectionsMicroButtons` could contain `nil` values, particularly when core Blizzard micro buttons were not fully initialized, leading to a runtime error during iteration. This PR adds robust nil and object type checks to prevent this.

---

[Open in Web](https://cursor.com/agents?id=bc-788de668-9148-41c6-ac35-ab29be0dbeb3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-788de668-9148-41c6-ac35-ab29be0dbeb3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)