### PR TITLE
Fix wow addon lua error

### DIFF
--- a/ezCollections/ezCollections.lua
+++ b/ezCollections/ezCollections.lua
@@ -973,7 +973,7 @@ function addon:OnInitialize()
                 -- Filter out nil buttons before assigning to prevent table index errors
                 local validButtons = {};
                 for i, button in ipairs(buttons) do
-                    if button and button:IsObjectType and button:IsObjectType("Button") then
+                    if button and button.IsObjectType and button:IsObjectType("Button") then
                         table.insert(validButtons, button);
                     end
                 end


### PR DESCRIPTION
Fix Lua syntax error 'function arguments expected near 'and'' by correcting method existence check for `IsObjectType`.

---

[Open in Web](https://cursor.com/agents?id=bc-4fbdf6fe-b225-4a57-8671-8dec82534cbf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4fbdf6fe-b225-4a57-8671-8dec82534cbf) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)