### PR TITLE
Fix ezcollections microbar nil index error

### DIFF
--- a/ezCollections/Core/ElvUI/MicroBar.lua
+++ b/ezCollections/Core/ElvUI/MicroBar.lua
@@ -11,7 +11,8 @@ local success, errorMsg = pcall(function()
 	-- Check if UpdateMicroButtonsParent exists before hooking
 	if AB.UpdateMicroButtonsParent then
 		hooksecurefunc(AB, "UpdateMicroButtonsParent", function(self)
-			if CollectionsMicroButton and ElvUI_MicroBar then
+			-- Ensure CollectionsMicroButton exists and is valid before setting parent
+			if CollectionsMicroButton and ElvUI_MicroBar and CollectionsMicroButton.IsObjectType and CollectionsMicroButton:IsObjectType("Button") then
 				CollectionsMicroButton:SetParent(ElvUI_MicroBar);
 				-- Removed problematic call to UpdateMicroPositionDimensions() since it doesn't exist
 				if AB.UpdateMicroButtons then
@@ -25,12 +26,40 @@ local success, errorMsg = pcall(function()
 	if AB.UpdateMicroButtons then
 		hooksecurefunc(AB, "UpdateMicroButtons", function(self)
 			if not ElvUI_MicroBar then return end
-			if not AB.ezCollectionsMicroButtons then return end
+			
+			-- Initialize ezCollectionsMicroButtons if it doesn't exist
+			if not AB.ezCollectionsMicroButtons then
+				AB.ezCollectionsMicroButtons = {}
+			end
+			
+			-- If ezCollectionsMicroButtons is empty, try to populate it with standard buttons plus CollectionsMicroButton
+			if #AB.ezCollectionsMicroButtons == 0 and CollectionsMicroButton then
+				local standardButtons = {
+					CharacterMicroButton,
+					SpellbookMicroButton,
+					TalentMicroButton,
+					AchievementMicroButton,
+					QuestLogMicroButton,
+					SocialsMicroButton,
+					PVPMicroButton,
+					LFDMicroButton,
+					MainMenuMicroButton,
+					HelpMicroButton,
+					CollectionsMicroButton
+				}
+				
+				-- Filter out nil buttons to prevent "table index is nil" error
+				for i, button in ipairs(standardButtons) do
+					if button and button.IsObjectType and button:IsObjectType("Button") then
+						table.insert(AB.ezCollectionsMicroButtons, button);
+					end
+				end
+			end
 			
 			-- Filter out nil buttons to prevent "table index is nil" error
 			local MICRO_BUTTONS = {};
 			for i, button in ipairs(AB.ezCollectionsMicroButtons) do
-				if button and button:IsObjectType("Button") then
+				if button and button.IsObjectType and button:IsObjectType("Button") then
 					table.insert(MICRO_BUTTONS, button);
 				end
 			end
@@ -69,7 +98,8 @@ local success, errorMsg = pcall(function()
 	-- Check if SetupMicroBar exists before hooking
 	if AB.SetupMicroBar then
 		hooksecurefunc(AB, "SetupMicroBar", function(self)
-			if CollectionsMicroButton and self.HandleMicroButton then
+			-- Ensure CollectionsMicroButton exists and is valid before handling
+			if CollectionsMicroButton and self.HandleMicroButton and CollectionsMicroButton.IsObjectType and CollectionsMicroButton:IsObjectType("Button") then
 				self:HandleMicroButton(CollectionsMicroButton);
 			end
 		end);

--- a/ezCollections/ezCollections.lua
+++ b/ezCollections/ezCollections.lua
@@ -931,6 +931,11 @@ function addon:OnInitialize()
         };
         local microButtonInserted;
         local function positionMicroButtons(buttons, inserted)
+            -- Ensure buttons parameter is valid
+            if not buttons then
+                buttons = {};
+            end
+            
             if Dominos and Dominos.MenuBar then
                 function Dominos.MenuBar:NumButtons()
                     return #buttons;
@@ -970,6 +975,11 @@ function addon:OnInitialize()
             if ElvUI then
                 local E = unpack(ElvUI);
                 local AB = E:GetModule("ActionBars");
+                -- Ensure buttons parameter is valid
+                if not buttons then
+                    buttons = {};
+                end
+                
                 -- Filter out nil buttons before assigning to prevent table index errors
                 local validButtons = {};
                 for i, button in ipairs(buttons) do
@@ -977,6 +987,12 @@ function addon:OnInitialize()
                         table.insert(validButtons, button);
                     end
                 end
+                
+                -- Initialize ezCollectionsMicroButtons if it doesn't exist
+                if not AB.ezCollectionsMicroButtons then
+                    AB.ezCollectionsMicroButtons = {};
+                end
+                
                 AB.ezCollectionsMicroButtons = validButtons;
                 -- Use UpdateMicroButtons instead of the non-existent UpdateMicroPositionDimensions
                 if AB.UpdateMicroButtons then


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes 'table index is nil' error in ElvUI MicroBar by ensuring `ezCollectionsMicroButtons` is properly initialized and validated.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error stemmed from a race condition where ElvUI's MicroBar module attempted to access the `ezCollectionsMicroButtons` table before it was fully populated or after it contained nil entries. This PR adds defensive programming, proper initialization, and nil checks to prevent premature access and ensure all button objects are valid before use, resolving the "table index is nil" error.

---

[Open in Web](https://cursor.com/agents?id=bc-bbbfd65a-8326-45b3-9029-8e975ad99f42) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bbbfd65a-8326-45b3-9029-8e975ad99f42) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)