### PR TITLE
Fix elvui ezcollections microbar error

### DIFF
--- a/ezCollections/Core/ElvUI/MicroBar.lua
+++ b/ezCollections/Core/ElvUI/MicroBar.lua
@@ -75,7 +75,12 @@ local success, errorMsg = pcall(function()
 			for i = 1, #MICRO_BUTTONS do
 				local button = MICRO_BUTTONS[i]
 				local lastColumnButton = i - self.db.microbar.buttonsPerRow
-				lastColumnButton = MICRO_BUTTONS[lastColumnButton];
+				-- Add bounds checking to prevent "table index is nil" error
+				if lastColumnButton > 0 and lastColumnButton <= #MICRO_BUTTONS then
+					lastColumnButton = MICRO_BUTTONS[lastColumnButton];
+				else
+					lastColumnButton = nil;
+				end
 
 				button:Size(self.db.microbar.buttonSize, self.db.microbar.buttonSize * 1.4)
 				button:ClearAllPoints()
@@ -83,7 +88,7 @@ local success, errorMsg = pcall(function()
 
 				if prevButton == ElvUI_MicroBar then
 					button:Point("TOPLEFT", prevButton, "TOPLEFT", offset, -offset)
-				elseif (i - 1) % self.db.microbar.buttonsPerRow == 0 then
+				elseif (i - 1) % self.db.microbar.buttonsPerRow == 0 and lastColumnButton then
 					button:Point("TOP", lastColumnButton, "BOTTOM", 0, -spacing)
 					numRows = numRows + 1
 				else


### PR DESCRIPTION
Fixes 'table index is nil' error in ezCollections MicroBar by adding bounds checking for button positioning.

The error occurred because `lastColumnButton` could be negative or zero when calculating button positions, leading to an invalid table index access in Lua (which is 1-indexed). This fix ensures `MICRO_BUTTONS` is accessed only with valid indices, preventing the error and restoring ElvUI action bar functionality.

---

[Open in Web](https://cursor.com/agents?id=bc-5e440909-35ce-4eae-9faf-eae0daeb2c43) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5e440909-35ce-4eae-9faf-eae0daeb2c43) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)